### PR TITLE
Added metadata for scanalyzer platform

### DIFF
--- a/sensors/scanalyzer/dataset.id
+++ b/sensors/scanalyzer/dataset.id
@@ -1,0 +1,1 @@
+https://terraref.ncsa.illinois.edu/clowder/api/datasets/5873eac64f0cad7d81349b0b

--- a/sensors/scanalyzer/sensor_fixed_metadata.json
+++ b/sensors/scanalyzer/sensor_fixed_metadata.json
@@ -1,8 +1,13 @@
 {
   "sensor_id": "scanalyzer",
-  "sensor_manufacturer": "LemnaTec",
+  "sensor_manufacturer": "LemnaTec Corp.",
   "sensor_product_name": "Field Scanalyzer",
-  "sensor_serial_number": "",
+  "sensor_serial_number": "7100019",
   "sensor_description": "Fully automated system designed to capture outdoor phenotyping data",
-  "sensor_purpose": ""
+  "sensor_purpose": "",
+  "system_scan_area_north_south_m": "211",
+  "system_scan_area_east_west_m": "23.125",
+  "system_scan_area_height_m": "8"
 }
+
+

--- a/sensors/scanalyzer/sensor_fixed_metadata.json
+++ b/sensors/scanalyzer/sensor_fixed_metadata.json
@@ -1,0 +1,8 @@
+{
+  "sensor_id": "scanalyzer",
+  "sensor_manufacturer": "LemnaTec",
+  "sensor_product_name": "Field Scanalyzer",
+  "sensor_serial_number": "",
+  "sensor_description": "Fully automated system designed to capture outdoor phenotyping data",
+  "sensor_purpose": ""
+}


### PR DESCRIPTION
Added stub metadata for scanalyzer platform. This gets posted to 

https://terraref.ncsa.illinois.edu/clowder/datasets/5873eac64f0cad7d81349b0b

If this works, we can put the rail_height, etc. here.